### PR TITLE
Remove confusing Azure alias in FAQ

### DIFF
--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -50,7 +50,7 @@ Services are currently available with a range of [instance sizes](<../Reference
 
 - Amazon AWS (Amazon Web Services)
 - Google GCP (Google Cloud Platform)
-- Microsoft Azure (Cloud Computing Services)
+- Microsoft Azure
 
 Transactional services (such as our Replicated Transactions topology) operate on:
 


### PR DESCRIPTION
I think that having the "Cloud Computing Services" clarification for Azure is only confusing (especially for the LLM semantic search).